### PR TITLE
Bugfix/preserve segment order

### DIFF
--- a/Healex.HL7v2Anonymizer.Tests/AnonymizerTests.cs
+++ b/Healex.HL7v2Anonymizer.Tests/AnonymizerTests.cs
@@ -45,7 +45,7 @@ namespace Healex.HL7v2Anonymizer.Tests
 
             // Assert
             Assert.IsTrue(originalMessage.SegmentCount == message.SegmentCount);
-            for (int i = 0; i < originalMessage.SegmentCount; i++)
+            for (var i = 0; i < originalMessage.SegmentCount; i++)
             {
                 var originalSegment = originalMessage.Segments().ElementAt(i);
                 var messageSegment = message.Segments().ElementAt(i);

--- a/Healex.HL7v2Anonymizer.Tests/AnonymizerTests.cs
+++ b/Healex.HL7v2Anonymizer.Tests/AnonymizerTests.cs
@@ -61,6 +61,7 @@ namespace Healex.HL7v2Anonymizer.Tests
             // Setup
             var replacementOptions = getReplacementOptions();
             message.ParseMessage();
+            originalMessage.ParseMessage();
 
             // Method under test
             var anonymizer = new Anonymizer(replacementOptions);
@@ -89,6 +90,7 @@ namespace Healex.HL7v2Anonymizer.Tests
 
             // Output for manual inspection
             var messageAsString = message.SerializeMessage(true);
+            var originalMessageAsString = originalMessage.SerializeMessage(true);
             Console.WriteLine(messageAsString);
         }
 

--- a/Healex.HL7v2Anonymizer/Services/Anonymizer.cs
+++ b/Healex.HL7v2Anonymizer/Services/Anonymizer.cs
@@ -1,5 +1,6 @@
 ﻿using HL7.Dotnetcore;
 using System;
+using System.Linq;
 using static Healex.HL7v2Anonymizer.ReplacementOptions;
 
 namespace Healex.HL7v2Anonymizer.Services
@@ -16,16 +17,16 @@ namespace Healex.HL7v2Anonymizer.Services
         public bool Anonymize(Message message)
         {
             var isSuccess = true;
-            foreach (SegmentReplacement segmentReplacement in _replacementOptions.Segments)
+
+            for (int segmentIndex = 0; segmentIndex < message.SegmentCount; segmentIndex++)
             {
-                var segments = message.Segments(segmentReplacement.Segment);
-                foreach (Segment segment in segments)
+                var segment = message.Segments().ElementAt(segmentIndex);
+                if (_replacementOptions.Segments.FirstOrDefault(segRep => segRep.Segment == segment.Name)
+                    is var segmentReplacement && segmentReplacement != null)
                 {
                     // Create new temporary message for each repeating segment 
                     // because we can't set values in all repeating segments at once
-                    var tempMessage = new Message();
-                    tempMessage.AddNewSegment(segment);
-
+                    var tempMessage = AddSegmentAtIndex(segment, segmentIndex);
                     foreach (Replacement replacement in segmentReplacement.Replacements)
                     {
                         var replacementValue = GetReplacementValue(replacement, message);
@@ -33,7 +34,21 @@ namespace Healex.HL7v2Anonymizer.Services
                     }
                 }
             }
+
             return isSuccess;
+        }
+
+        private Message AddSegmentAtIndex(Segment segment, int segmentIndex)
+        {
+            var tempMessage = new Message();
+
+            // workaround to ensure the segment gets it absolute (internal) SequenceNo re-assigned in AddNewSegment()
+            for (int i = 0; i < segmentIndex; i++)
+            {
+                tempMessage.AddNewSegment(new Segment("DummySegment", new HL7Encoding()));
+            }
+            tempMessage.AddNewSegment(segment);
+            return tempMessage;
         }
 
         private string GetReplacementValue(Replacement replacement, Message message)

--- a/Healex.HL7v2Anonymizer/Services/Anonymizer.cs
+++ b/Healex.HL7v2Anonymizer/Services/Anonymizer.cs
@@ -18,11 +18,11 @@ namespace Healex.HL7v2Anonymizer.Services
         {
             var isSuccess = true;
 
-            for (int segmentIndex = 0; segmentIndex < message.SegmentCount; segmentIndex++)
+            for (var segmentIndex = 0; segmentIndex < message.SegmentCount; segmentIndex++)
             {
                 var segment = message.Segments().ElementAt(segmentIndex);
                 if (_replacementOptions.Segments.FirstOrDefault(segRep => segRep.Segment == segment.Name)
-                    is var segmentReplacement && segmentReplacement != null)
+                    is { } segmentReplacement)
                 {
                     // Create new temporary message for each repeating segment 
                     // because we can't set values in all repeating segments at once
@@ -43,7 +43,7 @@ namespace Healex.HL7v2Anonymizer.Services
             var tempMessage = new Message();
 
             // workaround to ensure the segment gets it absolute (internal) SequenceNo re-assigned in AddNewSegment()
-            for (int i = 0; i < segmentIndex; i++)
+            for (var i = 0; i < segmentIndex; i++)
             {
                 tempMessage.AddNewSegment(new Segment("DummySegment", new HL7Encoding()));
             }

--- a/Healex.HL7v2Anonymizer/appsettings.json
+++ b/Healex.HL7v2Anonymizer/appsettings.json
@@ -146,10 +146,6 @@
                 "Segment": "NK1",
                 "Replacements": [
                     {
-                        "Path": "NK1.1.1",
-                        "Value":"HASH"
-                    },
-                    {
                         "Path": "NK1.2.1",
                         "Value": "Family Name"
                     },


### PR DESCRIPTION
This PR solves issue #3 

### Background
The reason for the segment order getting changed was that adding each segment that needs replacement to a temporary new Messages resulted in its (internal) SequenceNo getting re-setted to 0 (in AddNewSegment()).
This resulted in the message segements getting reordered when calling message.Segements() or message.SerializeMessage() as the segments are ordered by their SequenceNo internally. 

### Fix
This PR adds the following
- a **workaround** of adding as many "DummySegments" before the segment that needs replacements as needed to ensure the segment at hand gets its absolute (internal) SequenceNo re-assigned in AddNewSegment().
- fix for the existing tests as before always the catch of the try-catch-block was executed and thus no assertions were executed

### Outlook
However, this whole workaround (of creating a temporary message and adding "DummySegments") can be replaced if the here used package HL7-dotnetcore gets updated in a way to process repeating segments at once instead of only dealing with the first one.