### PR TITLE
feat: FT-239 Add output and suffix option

### DIFF
--- a/Healex.HL7v2Anonymizer/Options/Process.cs
+++ b/Healex.HL7v2Anonymizer/Options/Process.cs
@@ -8,5 +8,11 @@ namespace Healex.HL7v2Anonymizer.Options {
 
         [Option('d', "directory", Required = true, HelpText = "Directory name where all the HL7 files are located")]
         public string Directory { get; set; }
+        
+        [Option('o', "output", Required = false, HelpText = "Directory where changed HL7 files are written.")]
+        public string OutputDirectory { get; set; }
+        
+        [Option('a', "append", Required = false, HelpText ="A suffix to append to all filenames. For example '_Anonymized'")]
+        public string Suffix { get; set; }
     }
 }

--- a/README.md
+++ b/README.md
@@ -10,11 +10,27 @@ The project was built to enable anyone to share HL7v2 sample messages without id
 
 ## How to use?
 
-**Warning: This application overwrites the original message so make sure you are working on a copy.**
 
 1. Download the latest release to a location of your choice.
 2. Unzip it.
-3. Run the application and enter the path to your v2 messages. Make sure to back them up prior to runing the application since the original messages will be overwritten.
+3. Run the application with at least the `-d` or `--directory` option set <br>
+For example on windows run:
+`Healex.HL7v2Anonymizer.exe -d C:\Path\To\Files` <br>
+On Linux that would be `./Healex.Hl7v2Anonymizer -d /path/to/files`
+
+**Warning: This will overwrite the original message if no separate output directory is specified.**
+
+## Command line arguments
+The following arguments or options are supported
+
+| Short | Long | Required | Description                                                                                                                                               |                                                                                                                              
+| --- | --- | --- |-----------------------------------------------------------------------------------------------------------------------------------------------------------| 
+| -d | --directory | required | The path to the directory containing the files to be anonymized                                                                                           |
+| -o | --output | optional | The path to the directory where anonymized files should be written <br> If not set, files are overwritten in the directory specified with -d              |
+| -a | --append | optional | Defines a suffix that is to be appended to the filenames.<br>For example if "_Anonymized is set, all files will be written to {filename}_Anonymized.hl7." |
+| -h | --help | optional | displays the help message                                                                                                                                 | 
+
+
 
 ## Configuration
 


### PR DESCRIPTION
This PR adds two new options to the anonymizer:
* `-o` or `--output` where the user can specify which directory the anonymized messages should be written
* `-a` or `--append` where the user can specify a suffix for the filenames of the anonymized messages

Both of these options can be used to avoid overwriting the original files. 
For example not setting `-o`, but setting `-a _anonymized` is going to write anonymized files to the same directory, but not overwrite the original files, since the new filename is going to be `{originalFileName}_anonymized.hl7`. 

The options can also be combined.  