### PR TITLE
feat: FT-312 Add custom extension functions to set values (fix repeating segments while doing that)

### DIFF
--- a/Healex.HL7v2Anonymizer.Tests/AnonymizerTests.cs
+++ b/Healex.HL7v2Anonymizer.Tests/AnonymizerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Healex.HL7v2Anonymizer.Services;
 using HL7.Dotnetcore;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -15,6 +16,17 @@ namespace Healex.HL7v2Anonymizer.Tests
         #endregion
         
         #region Test Methods
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Anonymize_MultipleConfigsForSameSegment_Exception()
+        {
+            var testMessage = CreateDefaultTestMessage();
+            var testReplacements = CreateFaultyReplacementOptions();
+            var anonymizer = new Anonymizer(testReplacements);
+            anonymizer.Anonymize(testMessage);
+        }
+        
 
         [TestMethod]
         public void Anonymize_RepeatingSegment_AllSegmentsAnonymized()
@@ -344,6 +356,40 @@ namespace Healex.HL7v2Anonymizer.Tests
             };
             
             return replacementOptions;
+        }
+
+        private ReplacementOptions CreateFaultyReplacementOptions()
+        {
+            return new ReplacementOptions
+            {
+                Segments = new SegmentReplacement[]
+                {
+                    new SegmentReplacement()
+                    {
+                        Segment = "PID",
+                        Replacements = new[]
+                        {
+                            new Replacement
+                            {
+                                Path = "PID.5",
+                                Value = "Irrelevant"
+                            }
+                        }
+                    },
+                    new SegmentReplacement()
+                    {
+                        Segment = "PID",
+                        Replacements = new[]
+                        {
+                            new Replacement
+                            {
+                                Path = "PID.5",
+                                Value = "Irrelevant"
+                            }
+                        }
+                    }
+                }
+            };
         }
         #endregion
     }

--- a/Healex.HL7v2Anonymizer.Tests/AnonymizerTests.cs
+++ b/Healex.HL7v2Anonymizer.Tests/AnonymizerTests.cs
@@ -17,6 +17,22 @@ namespace Healex.HL7v2Anonymizer.Tests
         #region Test Methods
 
         [TestMethod]
+        public void Anonymize_RepeatingSegment_AllSegmentsAnonymized()
+        {
+            var testMessage = CreateDefaultTestMessage();
+            var testReplacements = CreateDefaultReplacementOptions();
+
+            var anonymizer = new Anonymizer(testReplacements);
+            anonymizer.Anonymize(testMessage);
+            var IN1s = testMessage.Segments("IN1");
+            IN1s.Count.Should().Be(2);
+            IN1s[0].Fields(2).Components(1).Value.Should().Be("InsuranceShort");
+            IN1s[1].Fields(2).Components(1).Value.Should().Be("");
+            IN1s[0].Fields(2).Components(2).Value.Should().Be("InsuranceLong");
+            IN1s[1].Fields(2).Components(2).Value.Should().Be("InsuranceLong");
+        }
+        
+        [TestMethod]
         public void Anonymize_NoRepetitionPid5_PatientNameNotInMessage()
         {
             var testMessage = CreateDefaultTestMessage();
@@ -132,11 +148,12 @@ namespace Healex.HL7v2Anonymizer.Tests
                 "MSH|^~\\&|iMedOne^BTS|Ein1^123456789|Cloverleaf|Cloverleaf|20220101000000||ADT^A01|12345678|P|2.4|||AL|NE\n" +
                 "EVN|A01|20220101000000|||NeoGeo|20220101000000|Ein1\n" +
                 $"PID|1||101010^^^Ein1^PI||{pid5}||19990101|M|||Musterstraße 1^^Musterstadt^^4830^D^H~^^^^^^O||0180-12345^PRN^PH^^^^018012345~^PRN^FX^~^PRN^CP^~^NET^X.400^|^WPN^PH|Deutsch|verheiratet|KA||||||Malchin|N||D|Arbeiter|||N|||20220101000000\n" +
-                "NK1|1|Mustermann ^Maxima|Ehefrau|Musterstraße 1^^Musterstadt^^4830^D|0180-12345^NO|||20200101|||||||||||||||||||||||||1010\n" +
+                "NK1|1|Mustermann^Maxima|Ehefrau|Musterstraße 1^^Musterstadt^^4830^D|0180-12345^NO|||20200101|||||||||||||||||||||||||1010\n" +
                 "NK1|2|Mustermann^Maxima|Ehefrau|Musterstraße 1^^Musterstadt^^4830^D|0180-12345^NO|||20200101|||||||||||||||||||||||||101010\n" +
                 "PV1|1|I|A4^^^RMED^^N|Notfall||^^^^^N|||123456789^Mustertyp^Maximus^^^Dr. med.^^LANR^^^^^^123456789|R-N||J||||0|||1234567^^^Ein1^VN|Standard||||K||||20220101000000||||||||0101||||||||20220101000000|\n" +
                 "PV2|||0101|||||||||Notfall||||||||||||||||||||||||N\n" +
-                "IN1|1|VKK^VdAK|123456789^^^DAK^NII~K101^^^DAK^NIIP|DAK|Postfach^^Musterburg^^2000^DE|~|||primaer|||19980202|||R^1|^||19980202|Musterallee^^^^2000^D||||||||||20220101|||||||D123456789|||||||M||||||D123456789\n";
+                "IN1|1|VKK^VdAK|123456789^^^DAK^NII~K101^^^DAK^NIIP|DAK|Postfach^^Musterburg^^2000^DE|~|||primaer|||19980202|||R^1|^||19980202|Musterallee^^^^2000^D||||||||||20220101|||||||D123456789|||||||M||||||D123456789\n"+
+                "IN1|2|^Mimimimi|123456789^^^DAK^NII~K101^^^DAK^NIIP|DAK|Postfach^^Musterburg^^2000^DE|~|||primaer|||19980202|||R^1|^||19980202|Musterallee^^^^2000^D||||||||||20220101|||||||D123456789|||||||M||||||D123456789\n";
 
             var message = new Message(messageString);
             message.ParseMessage();
@@ -244,6 +261,8 @@ namespace Healex.HL7v2Anonymizer.Tests
                         Segment = "IN1",
                         Replacements = new[]
                         {
+                            new Replacement { Path = "IN1.2.1", Value = "InsuranceShort" },
+                            new Replacement { Path = "IN1.2.2", Value = "InsuranceLong" },
                             new Replacement { Path = "IN1.6.1", Value = "Family Name" },
                             new Replacement { Path = "IN1.6.2", Value = "Given Name" },
                             new Replacement { Path = "IN1.6.3", Value = "Second name" },

--- a/Healex.HL7v2Anonymizer/Extensions/MessageElementExtensions.cs
+++ b/Healex.HL7v2Anonymizer/Extensions/MessageElementExtensions.cs
@@ -1,0 +1,115 @@
+using Healex.HL7v2Anonymizer.Services;
+using HL7.Dotnetcore;
+
+namespace Healex.HL7v2Anonymizer.Extensions;
+
+public static class MessageElementExtensions
+{
+    public static bool TrySetValue(this Segment segment, string path, string replacementValue)
+    {
+        var parts = path.Split(".");
+        switch (parts.Length)
+            {
+                case 2:
+                {
+                    // field replacement
+                    var fieldIndex = int.Parse(parts[1]);
+                    var field = segment.Fields(fieldIndex);
+                    field.SetValue(replacementValue);
+                    return true;
+                }
+                case 3:
+                {
+                    // component replacement
+                    var fieldIndex = int.Parse(parts[1]);
+                    var compIndex = int.Parse(parts[2]);
+                    var field = segment.Fields(fieldIndex);
+                    // if the field does not exist, we do not need to look any further
+                    if (field == null) return false;
+                    var component = field.Components(compIndex);
+                    component.SetValue(replacementValue);
+                    
+                    // check for the component in repetitions of the field
+                    if (field.HasRepetitions)
+                    {
+                        foreach (var rep in field.Repetitions())
+                        {
+                            var repComponent = rep.Components(compIndex);
+                            repComponent.SetValue(replacementValue);
+                        }
+                    }
+                    return true;
+                }
+                case 4:
+                {
+                    //subcomponent replacement
+                    var fieldIndex = int.Parse(parts[1]);
+                    var compIndex = int.Parse(parts[2]);
+                    var subCompIndex = int.Parse(parts[3]);
+                    var field = segment.Fields(fieldIndex);
+                    // if the field is null, we do not have to look any further
+                    if (field == null) return false;
+                    var component = field.Components(compIndex);
+                    
+                    // if the component is null, it still might be present in a repetition. 
+                    // Thus, no return here.
+                    if (component != null) 
+                    {
+                        var subComponent = component.SubComponents(subCompIndex);
+                        subComponent.SetValue(replacementValue);
+                    }
+                    
+                    // do the same for repetitions
+                    if (field.HasRepetitions)
+                    {
+                        foreach (var rep in field.Repetitions())
+                        {
+                            var repComponent = rep.Components(compIndex);
+                            if (repComponent != null)
+                            {
+                                var repSubComponent = repComponent.SubComponents(subCompIndex);
+                                repSubComponent.SetValue(replacementValue);
+                            }
+                        }
+                    }
+                    return true;
+                }
+            }
+            return false;
+        }
+
+    public static void SetValue(this Field field, string value)
+    {
+        if (field == null) return;
+        field.Value = GetReplacement(field.Value, value);
+
+        if (!field.HasRepetitions) return;
+        foreach (var rep in field.Repetitions())
+        {
+            rep.Value = value;
+        }
+    }
+
+    public static void SetValue(this Component component, string value)
+    {
+        if (component == null) return;
+        component.Value = GetReplacement(component.Value, value);
+    }
+
+    public static void SetValue(this SubComponent subComponent, string value)
+    {
+        if (subComponent == null) return;
+        subComponent.Value = GetReplacement(subComponent.Value, value);
+    }
+
+    public static string GetReplacement(string originalValue, string replacementValue)
+    {
+        if (string.IsNullOrEmpty(originalValue)) return "";
+        if (replacementValue == "HASH")
+        {
+            return HashGenerator.HashString(originalValue);
+        }
+
+        return replacementValue;
+    }
+}

--- a/Healex.HL7v2Anonymizer/Extensions/MessageElementExtensions.cs
+++ b/Healex.HL7v2Anonymizer/Extensions/MessageElementExtensions.cs
@@ -89,19 +89,13 @@ public static class MessageElementExtensions
             rep.Value = value;
         }
     }
-
-    public static void SetValue(this Component component, string value)
+    
+    public static void SetValue(this MessageElement element, string value)
     {
-        if (component == null) return;
-        component.Value = GetReplacement(component.Value, value);
+        if (element == null) return;
+        element.Value = GetReplacement(element.Value, value);
     }
-
-    public static void SetValue(this SubComponent subComponent, string value)
-    {
-        if (subComponent == null) return;
-        subComponent.Value = GetReplacement(subComponent.Value, value);
-    }
-
+    
     public static string GetReplacement(string originalValue, string replacementValue)
     {
         if (string.IsNullOrEmpty(originalValue)) return "";

--- a/Healex.HL7v2Anonymizer/Services/Anonymizer.cs
+++ b/Healex.HL7v2Anonymizer/Services/Anonymizer.cs
@@ -1,5 +1,4 @@
 ﻿using HL7.Dotnetcore;
-using System;
 using System.Linq;
 using Healex.HL7v2Anonymizer.Extensions;
 
@@ -39,7 +38,6 @@ namespace Healex.HL7v2Anonymizer.Services
                 }
             }
         }
-
         #endregion
     }
 }

--- a/Healex.HL7v2Anonymizer/Services/Anonymizer.cs
+++ b/Healex.HL7v2Anonymizer/Services/Anonymizer.cs
@@ -1,4 +1,5 @@
-﻿using HL7.Dotnetcore;
+﻿using System;
+using HL7.Dotnetcore;
 using System.Linq;
 using Healex.HL7v2Anonymizer.Extensions;
 
@@ -27,14 +28,17 @@ namespace Healex.HL7v2Anonymizer.Services
         {
             foreach (var segment in message.Segments())
             {
-                var rules = options.Segments.Where(replacement => replacement.Segment == segment.Name)
-                    .Select(replacement => replacement.Replacements);
-                foreach (var rule in rules)
+                var rules = options.Segments.Where(replacement => replacement.Segment == segment.Name).ToList();
+                if (rules.Count > 1)
                 {
-                    foreach (var replacement in rule)
-                    {
-                        segment.TrySetValue(replacement.Path, replacement.Value);
-                    }
+                    throw new ArgumentException(
+                        $"Found multiple replacement configurations for segment {segment.Name}");
+                }
+                var rule = rules.FirstOrDefault();
+                if (rule == null) continue;
+                foreach (var replacement in rule.Replacements)
+                {
+                    segment.TrySetValue(replacement.Path, replacement.Value);
                 }
             }
         }


### PR DESCRIPTION
This PR: 
- adds extension functions for setting values in 
    - fields
    - components
    - subcomponents
- utilizes these functions instead of the previously used method of accessing the values via path on the message
- fixes the issue where repeating segments where not completely anonymized, when a previous repetition did not have a field that should be anonymized

Please have a look and if you find any edge cases that I forgot, please let me know :) 
