### PR TITLE
hash patient-id in MRG segments

### DIFF
--- a/Healex.HL7v2Anonymizer/appsettings.json
+++ b/Healex.HL7v2Anonymizer/appsettings.json
@@ -592,6 +592,15 @@
                         "Value": "867-5309"
                     }
                 ]
+            },
+            {
+                "Segment": "MRG",
+                "Replacements": [
+                    {
+                        "Path": "MRG.1",
+                        "Value":"HASH"
+                    }
+                ]
             }
         ]
     }


### PR DESCRIPTION
By default, the Patient ID(s) in MRG segments are not anonymized. This PR hashes the patient ID. This allows a connection to be made between all messages belonging to the two patient IDs that have been merged.

Note: This PR will only fully work for MRG segments that have a single patient ID in MRG.1, if there is a list of IDs (as the standard allows) the hash created will not be helpful in making the connection (of course the benefit of anonymization is still there).

For more details on MRG segments, see 
https://hl7-definition.caristix.com/v2/HL7v2.4/Segments/MRG